### PR TITLE
Tdr 2478 tree vew accessibility 2

### DIFF
--- a/app/assets/sass/patterns/_tree-view-file-navigation.scss
+++ b/app/assets/sass/patterns/_tree-view-file-navigation.scss
@@ -100,8 +100,51 @@
     border-color: $govuk-link-colour;
   }
 
-  // https://github.com/alphagov/govuk-frontend/issues/1453#issue-455823968
-  .govuk-checkboxes__input:indeterminate + .govuk-checkboxes__label::after {
+  .govuk-tna-tree .govuk-checkboxes__label {
+    white-space: nowrap;
+  }
+
+
+  /*
+   * Using same CSS as govuk-frontend checkboxes component:
+   * https://github.com/alphagov/govuk-frontend/blob/137b806d7c308f98f75f8c78ecfdb7f760b27d39/package/govuk/components/checkboxes/_index.scss#L128
+   * Not including the IE8 stuff.
+   * */
+
+  [role="treeitem"]:focus > .govuk-checkboxes__item > .govuk-checkboxes__label:before,
+  [role="treeitem"]:focus > .govuk-tna-tree__folder-item__container > .govuk-checkboxes__item > .govuk-checkboxes__label:before {
+    border-width: 4px;
+
+    // When colours are overridden, the yellow box-shadow becomes invisible
+    // which means the focus state is less obvious. By adding a transparent
+    // outline, which becomes solid (text-coloured) in that context, we ensure
+    // the focus remains clearly visible.
+    outline: $govuk-focus-width solid transparent;
+    outline-offset: 1px;
+
+    // When in an explicit forced-color mode, we can use the Highlight system
+    // color for the outline to better match focus states of native controls
+    @media screen and (forced-colors: active), (-ms-high-contrast: active) {
+      outline-color: Highlight;
+    }
+
+    box-shadow: 0 0 0 $govuk-focus-width $govuk-focus-colour;
+  }
+
+
+
+  [role="treeitem"][aria-selected="true"] > .govuk-checkboxes__item > .govuk-checkboxes__label:after,
+  [role="treeitem"][aria-selected="true"] > .govuk-tna-tree__folder-item__container > .govuk-checkboxes__item > .govuk-checkboxes__label:after {
+    opacity: 1;
+  }
+
+
+  /*
+   * Styles pilfered from this thread:
+   * https://github.com/alphagov/govuk-frontend/issues/1453#issue-455823968
+   * */
+  [role="treeitem"][aria-checked="mixed"] > .govuk-checkboxes__item > .govuk-checkboxes__label:after,
+  [role="treeitem"][aria-checked="mixed"] > .govuk-tna-tree__folder-item__container > .govuk-checkboxes__item > .govuk-checkboxes__label:after {
     transform: rotate(0);
     border: none;
     top: 0;
@@ -111,8 +154,4 @@
     width: 22px;
     background: currentColor;
     opacity: 1;
-  }
-
-  .govuk-tna-tree .govuk-checkboxes__label {
-    white-space: nowrap;
   }

--- a/app/assets/typescript/tree-view.ts
+++ b/app/assets/typescript/tree-view.ts
@@ -1,4 +1,6 @@
 const tree: HTMLUListElement | null = document.querySelector("[role=tree]");
+const treeItems = document.querySelectorAll("[role=treeitem]");
+let currentFocus: HTMLLIElement = null;
 
 if (tree) {
   const getExpanded: () => string[] = () => {
@@ -10,55 +12,52 @@ if (tree) {
     }
   };
 
-  const allCheckboxes: (
+  const allChildren: (
     ul: HTMLUListElement,
-    elements: HTMLInputElement[]
-  ) => HTMLInputElement[] = (ul, elements) => {
+    elements: HTMLLIElement[]
+  ) => HTMLLIElement[] = (ul, elements) => {
     for (let i = ul.children.length - 1; i >= 0; i--) {
       const item: HTMLLIElement | null = ul.children.item(
         i
       ) as HTMLLIElement | null;
-      if (item) {
-        if (item.nodeName == "LI") {
-          const itemCheckbox: HTMLInputElement | null = item.querySelector(
-            "input[type=checkbox]"
-          );
-          if (itemCheckbox) {
-            elements.push(itemCheckbox);
-          }
-        }
-        // If children includes a UL/role=group then get children
-        Array.from(item.children)
-          .filter((el) => el.nodeName == "UL")
-          .forEach((el) => allCheckboxes(el as HTMLUListElement, elements));
+
+      if (item && item.nodeName == "LI") {
+        elements.push(item);
       }
+      // If children includes a UL/role=group then get children
+      Array.from(item.children)
+        .filter((el) => el.nodeName == "UL")
+        .forEach((el) => allChildren(el as HTMLUListElement, elements));
     }
     return elements;
   };
 
-  const setCheckbox: (input: HTMLInputElement) => void = (input) => {
-    const li: HTMLLIElement | null = input.parentElement.closest("li");
-    li.setAttribute(
-      "aria-selected",
-      li.getAttribute("aria-selected") == "false" ? "true" : "false"
-    );
+  const setSelected: (li: HTMLLIElement) => void = (li) => {
+    const isSelected: Boolean = li.getAttribute("aria-selected") == "true";
+    li.setAttribute("aria-selected", isSelected == false ? "true" : "false");
+    li.setAttribute("aria-checked", isSelected == false ? "true" : "false");
 
     // If this is a folder, traverse down
     if (li.hasAttribute("aria-expanded")) {
       const childrenGroup: HTMLUListElement | null = document.querySelector(
-        `#folder-group-${input.id}`
+        `#folder-group-${li.id}`
       );
       if (childrenGroup) {
-        const checkboxes = allCheckboxes(childrenGroup, []);
-        for (let checkbox of checkboxes) {
-          checkbox.checked = input.checked;
-          checkbox.indeterminate = false;
-          checkbox.setAttribute("aria-checked", input.checked.toString());
+        const children = allChildren(childrenGroup, []);
+        for (let child of children) {
+          child.setAttribute(
+            "aria-selected",
+            isSelected == false ? "true" : "false"
+          );
+          child.setAttribute(
+            "aria-checked",
+            isSelected == false ? "true" : "false"
+          );
         }
       }
     }
     // Traverse up
-    const parentGroup: HTMLUListElement | null = input.closest("[role=group]");
+    const parentGroup: HTMLUListElement | null = li.closest("[role=group]");
     setParentState(parentGroup);
   };
 
@@ -85,30 +84,25 @@ if (tree) {
   const setParentState: (ul: HTMLUListElement | null) => void = (ul) => {
     // Gets all descendant checkboxes & sets UL parent checkbox accordingly
     if (ul) {
-      const all = allCheckboxes(ul, []);
+      const all = allChildren(ul, []);
       const countChecked = all.filter(
-        (a) => a.checked || a.indeterminate
+        (a) => a.getAttribute("aria-selected") == "true"
       ).length;
-
-      const parentCheckbox: HTMLInputElement | null =
-        ul.parentNode!.querySelector("input[type=checkbox]");
-      if (parentCheckbox && ul.getAttribute("role") != "tree") {
+      const parentLI: HTMLLIElement | null = ul.parentNode as HTMLLIElement;
+      if (parentLI && ul.getAttribute("role") != "tree") {
         // One or more children but less than all
         if (countChecked > 0 && countChecked < all.length) {
-          parentCheckbox.indeterminate = true;
-          parentCheckbox.setAttribute("aria-checked", "mixed");
+          parentLI.setAttribute("aria-checked", "mixed");
         }
         // All children checked
         if (countChecked == all.length) {
-          parentCheckbox.indeterminate = false;
-          parentCheckbox.checked = true;
-          parentCheckbox.setAttribute("aria-checked", "true");
+          parentLI.setAttribute("aria-checked", "true");
+          parentLI.setAttribute("aria-selected", "true");
         }
         // None checked
         if (countChecked == 0) {
-          parentCheckbox.checked = false;
-          parentCheckbox.indeterminate = false;
-          parentCheckbox.setAttribute("aria-checked", "false");
+          parentLI.setAttribute("aria-selected", "false");
+          parentLI.setAttribute("aria-checked", "false");
         }
         // Recursively call closest parent folder.
         const nextEl: HTMLUListElement | null | undefined =
@@ -121,17 +115,17 @@ if (tree) {
   };
 
   const setFocusToItem: (element: HTMLElement) => void = (element) => {
-    const input: HTMLInputElement | null = element?.querySelector(
-      "input[type=checkbox]"
-    );
-    if (input) {
-      input.tabIndex = 0;
-      input.focus();
+    Array.from(treeItems).forEach((item) => {
+      (item as HTMLElement).tabIndex = -1;
+    });
+    if (element) {
+      element.tabIndex = 0;
+      element.focus();
+      currentFocus = element as HTMLLIElement;
     }
   };
 
-  const setFocusToPreviousItem: (input: HTMLElement) => void = (input) => {
-    const li: HTMLLIElement | null = input.closest("li");
+  const setFocusToPreviousItem: (li: HTMLLIElement) => void = (li) => {
     // Do you have a sibling
     if (li && li.previousElementSibling) {
       // Does sibling have an aria-expanded=true
@@ -150,9 +144,7 @@ if (tree) {
     }
   };
 
-  const setFocusToNextItem: (input: HTMLElement) => void = (input) => {
-    const li: HTMLLIElement | null = input.closest("li");
-
+  const setFocusToNextItem: (li: HTMLLIElement) => void = (li) => {
     // Do you have a child
     if (li.getAttribute("aria-expanded") == "true") {
       // go to first child
@@ -176,58 +168,49 @@ if (tree) {
     .addEventListener("keydown", (ev: KeyboardEvent) => {
       const currentItem = document.activeElement;
       let li;
-      // console.log(ev.key);
+      // console.log(ev.key, ev.target);
       switch (ev.key) {
         case "Enter":
         case " ":
           // Check or uncheck checkbox
-          const input = ev.target as HTMLInputElement;
-          input.checked = !input.checked;
-          input.indeterminate = false;
-          setCheckbox(input);
+          setSelected(currentFocus);
           ev.preventDefault();
           break;
 
         case "ArrowUp":
           // Moves focus to the previous node that is focusable without opening or closing a node.
-          setFocusToPreviousItem(ev.target as HTMLElement);
+          setFocusToPreviousItem(currentFocus);
           ev.preventDefault();
           break;
 
         case "ArrowDown":
           // Moves focus to the next node that is focusable without opening or closing a node.
-          setFocusToNextItem(ev.target as HTMLElement);
+          setFocusToNextItem(currentFocus);
           ev.preventDefault();
           break;
 
         case "ArrowRight":
-          li = (ev.target as HTMLElement).closest("li");
-
-          if (li.getAttribute("aria-expanded") == "false") {
+          if (currentFocus.getAttribute("aria-expanded") == "false") {
             // When focus is on a closed node, opens the node; focus does not move.
-            toggleFolder(
-              li,
-              (ev.target as HTMLElement).id.replace("expander-", "")
-            );
-          } else if (li.getAttribute("aria-expanded") == "true") {
+            toggleFolder(currentFocus, currentFocus.id);
+          } else if (currentFocus.getAttribute("aria-expanded") == "true") {
             // When focus is on a open node, moves focus to the first child node.
-            setFocusToNextItem(ev.target as HTMLElement);
+            setFocusToNextItem(currentFocus);
           }
           // When focus is on an end node (a tree item with no children), does nothing.
           ev.preventDefault();
           break;
 
         case "ArrowLeft":
-          li = (ev.target as HTMLElement).closest("li");
-          if (li.getAttribute("aria-expanded") == "true") {
+          // li = (ev.target as HTMLElement).closest("li");
+          if (currentFocus.getAttribute("aria-expanded") == "true") {
             // When focus is on an open node, closes the node.
-            toggleFolder(
-              li,
-              (ev.target as HTMLElement).id.replace("expander-", "")
-            );
-          } else if (li.getAttribute("role") != "tree") {
+            toggleFolder(currentFocus, currentFocus.id);
+          } else if (currentFocus.getAttribute("role") != "tree") {
             // When focus is on a child node that is also either an end node or a closed node, moves focus to its parent node.
-            setFocusToItem(li.parentElement.closest("li") as HTMLElement);
+            setFocusToItem(
+              currentFocus.parentElement.closest("li") as HTMLElement
+            );
           }
           // When focus is on a closed `tree`, does nothing.
           ev.preventDefault();
@@ -294,15 +277,22 @@ if (tree) {
   });
 
   document
-    .querySelectorAll("[role=tree] [type=checkbox]")
-    .forEach((checkBox, key, parent) => {
-      checkBox.addEventListener("change", (ev) => {
-        if (ev.target instanceof HTMLInputElement) {
-          setCheckbox(ev.target);
+    .querySelectorAll("[role=treeitem]")
+    .forEach((treeitem, key, parent) => {
+      treeitem.addEventListener("click", (ev) => {
+        if (ev.currentTarget instanceof HTMLLIElement) {
+          setSelected(ev.currentTarget);
+          setFocusToItem(ev.currentTarget);
         }
+        ev.stopImmediatePropagation();
       });
     });
 
+  /*
+   * When tree receives focus from previous elements
+   * focus on first selected node, else focus on
+   * first node.
+   * */
   tree.addEventListener("focus", () => {
     const firstSelected = document.querySelector(
       "[role=treeitem][aria-selected=true]"
@@ -313,4 +303,38 @@ if (tree) {
       setFocusToItem(tree.firstElementChild as HTMLElement);
     }
   });
+
+  /*
+   * Convert all govuk checkboxes into spans to not
+   * confuse screenreaders. `<input>` and `<label>`
+   * both converted to spans and attributes copied
+   * excluding those that do not exist on spans.
+   * */
+  document
+    .querySelectorAll("[role=tree] .govuk-checkboxes__item")
+    .forEach((checkbox: HTMLElement) => {
+      const input: HTMLInputElement = checkbox.querySelector("input");
+      const label: HTMLLabelElement = checkbox.querySelector("label");
+
+      const spanInput = document.createElement("span");
+      for (const name of input.getAttributeNames()) {
+        if (!["type"].includes(name)) {
+          spanInput.setAttribute(name, input.getAttribute(name));
+        }
+        spanInput.setAttribute("aria-hidden", "true");
+      }
+
+      input.parentElement.appendChild(spanInput);
+      input.remove();
+
+      const spanLabel = document.createElement("span");
+      for (const name of label.getAttributeNames()) {
+        if (!["for"].includes(name)) {
+          spanLabel.setAttribute(name, label.getAttribute(name));
+        }
+      }
+      spanLabel.appendChild(document.createTextNode(label.textContent));
+      label.parentElement.appendChild(spanLabel);
+      label.remove();
+    });
 }

--- a/app/views/metadata/closure-metadata/file-level.html
+++ b/app/views/metadata/closure-metadata/file-level.html
@@ -73,14 +73,15 @@ File level closure metadata
           <li
         class="govuk-tna-tree__file-item"
         role="treeitem"
+        id="{{level}}-{{pos}}"
         aria-selected="false"
         aria-level="{{level}}"
         aria-setsize="{{size}}"
         aria-posinset="{{pos}}"
       >
             <div class="govuk-checkboxes__item">
-              <input class="govuk-checkboxes__input" id="{{level}}-{{pos}}" tabindex="-1" type="checkbox"/>
-              <label class="govuk-label govuk-checkboxes__label" for="{{level}}-{{pos}}">
+              <input class="govuk-checkboxes__input" id="checkbox-{{level}}-{{pos}}" tabindex="-1" type="checkbox"/>
+              <label class="govuk-label govuk-checkboxes__label" for="checkbox-{{level}}-{{pos}}">
                 {{item.name}}
                 {% if item.name == "Baking powder.docx" and data['closure']['baking-powder'][0] === 'true' %}
                   <span class="icon" aria-label="Has existing metadata">
@@ -95,6 +96,7 @@ File level closure metadata
           <li
           class="govuk-tna-tree__folder-item"
           role="treeitem"
+          id="{{level}}-{{pos}}"
           aria-expanded="true"
           aria-selected="false"
           aria-level="{{level}}"
@@ -112,13 +114,11 @@ File level closure metadata
               <div class="govuk-checkboxes__item">
                 <input
               class="govuk-checkboxes__input"
-              id="{{level}}-{{pos}}"
+              id="checkbox-{{level}}-{{pos}}"
               tabindex="-1"
-              type="checkbox"
-/>
-                <label class="govuk-label govuk-checkboxes__label" for="{{level}}-{{pos}}">
+              type="checkbox"/>
+                <label class="govuk-label govuk-checkboxes__label" for="checkbox-{{level}}-{{pos}}">
                   {{item.name}}
-                  <span class="govuk-visually-hidden"> Directory</span>
                   {% if item.name == "Baking powder.docx" and data['closure']['baking-powder'][0] === 'true' %}
                     <span class="icon" aria-label="Has existing metadata">
                       <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M20.285 2l-11.285 11.567-5.286-5.011-3.714 3.716 9 8.728 15-15.285z"/></svg>
@@ -143,137 +143,7 @@ File level closure metadata
             {{ fileItem(node, 1, loop.length, loop.index) }}
           {% endfor %}
         </ul>
-        {# <ul class="govuk-tna-tree__nested-file-list" role="tree" aria-multiselectable="true">
 
-          <li class="govuk-tna-tree__file-item" role="treeitem" aria-selected="false">
-            <div class="govuk-checkboxes__item">
-              <input class="govuk-checkboxes__input" id="1" type="checkbox">
-              <label class="govuk-label govuk-checkboxes__label" for="1">
-                Chocolate chips.xls
-
-              </label>
-            </div>
-          </li>
-
-          <li class="govuk-tna-tree__file-item" role="treeitem" aria-selected="false">
-            <div class="govuk-checkboxes__item">
-              <input class="govuk-checkboxes__input" id="2" type="checkbox">
-              <label class="govuk-label govuk-checkboxes__label" for="2">
-                Baking soda.xlsx
-
-              </label>
-            </div>
-          </li>
-
-          <li class="govuk-tna-tree__file-item" role="treeitem" aria-selected="false">
-            <div class="govuk-checkboxes__item">
-              <input class="govuk-checkboxes__input" id="13" type="checkbox">
-              <label class="govuk-label govuk-checkboxes__label" for="13">
-                Baking powder.docx
-
-              </label>
-            </div>
-          </li>
-
-          <li class="govuk-tna-tree__file-item" role="treeitem" aria-selected="false">
-            <div class="govuk-checkboxes__item">
-              <input class="govuk-checkboxes__input" id="3" type="checkbox">
-              <label class="govuk-label govuk-checkboxes__label" for="3">
-                Baking powder1.pdf
-
-              </label>
-            </div>
-          </li>
-
-          <li class="govuk-tna-tree__file-item" role="treeitem" aria-selected="false">
-            <div class="govuk-checkboxes__item">
-              <input class="govuk-checkboxes__input" id="4" type="checkbox">
-              <label class="govuk-label govuk-checkboxes__label" for="4">
-                Cookie dough.pdf
-
-              </label>
-            </div>
-          </li>
-
-          <li class="govuk-tna-tree__file-item" role="treeitem" aria-selected="false">
-            <div class="govuk-checkboxes__item">
-              <input class="govuk-checkboxes__input" id="5" type="checkbox">
-              <label class="govuk-label govuk-checkboxes__label" for="5">
-                Baking powder2.xlsx
-
-              </label>
-            </div>
-          </li>
-
-          <li class="govuk-tna-tree__folder-item" role="treeitem" aria-expanded="false" aria-selected="false">
-            <div class="govuk-tna-tree__folder-item__container">
-              <button class="govuk-tna-tree__file-expander" tabindex="-1" id="expander-6">
-                <span class="govuk-visually-hidden">Expand</span>
-              </button>
-              <div class="govuk-checkboxes__item">
-                <input class="govuk-checkboxes__input" id="6" type="checkbox" tabindex="0">
-                <label class="govuk-label govuk-checkboxes__label" for="6">
-                  Images
-
-                </label>
-              </div>
-            </div>
-            <ul class="govuk-tna-tree__nested-file-list" role="group" id="folder-group-6">
-
-              <li class="govuk-tna-tree__file-item" role="treeitem" aria-selected="false">
-                <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" id="7" type="checkbox">
-                  <label class="govuk-label govuk-checkboxes__label" for="7">
-                Flour.jpg
-
-              </label>
-                </div>
-              </li>
-
-              <li class="govuk-tna-tree__file-item" role="treeitem" aria-selected="false">
-                <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" id="8" type="checkbox">
-                  <label class="govuk-label govuk-checkboxes__label" for="8">
-                Sugar.jpg
-
-              </label>
-                </div>
-              </li>
-
-              <li class="govuk-tna-tree__file-item" role="treeitem" aria-selected="false">
-                <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" id="9" type="checkbox">
-                  <label class="govuk-label govuk-checkboxes__label" for="9">
-                Milk and cream.jpg
-
-              </label>
-                </div>
-              </li>
-
-              <li class="govuk-tna-tree__file-item" role="treeitem" aria-selected="false">
-                <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" id="10" type="checkbox">
-                  <label class="govuk-label govuk-checkboxes__label" for="10">
-                Cocoa.jpg
-
-              </label>
-                </div>
-              </li>
-
-              <li class="govuk-tna-tree__file-item" role="treeitem" aria-selected="false">
-                <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" id="11" type="checkbox">
-                  <label class="govuk-label govuk-checkboxes__label" for="11">
-                Bananas.jpg
-
-              </label>
-                </div>
-              </li>
-
-            </ul>
-          </li>
-
-        </ul> #}
       </div>
 
       <br/><br/>


### PR DESCRIPTION
Proposed changes accomodate screen readers. 
Replaces input and label with spans because screen readers get confused with input elements. 
Change to JS to accomodate this. 
Visually they look like checkboxes. 
With no JS there will also still be checkboxes. 